### PR TITLE
Add get port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,12 @@ or (this is unverified)
 docker inspect -f '{{ .NetworkSettings.IPAddress }}' <container_name>
 ```
 
+### Get port mapping
+
+```
+docker inspect -f '{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' <containername>
+```
+
 ### Get Environment Settings
 
 ```


### PR DESCRIPTION
Added an example for listing the port mapping of a container. When using dynamic mapping it can be helpful to get a list of all ports and to what port they are mapped.

Example:
8080/tcp -> 8080
8081/tcp -> 8081
