### PR TITLE
Add filter for stopped containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ docker ps -a | grep 'weeks ago' | awk '{print $1}' | xargs docker rm
 ### Delete stopped containers
 
 ```
-docker rm `docker ps -a -q`
+docker rm `docker ps -a -q -f status=exited`
 ```
 
 ### Delete dangling images


### PR DESCRIPTION
and avoid "Error response from daemon: You cannot remove a running container. Stop the container before attempting removal or use -f"
