### PR TITLE
Prevent container cleanup from creating orphan volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ docker ps -a | grep 'weeks ago' | awk '{print $1}' | xargs docker rm
 ### Delete stopped containers
 
 ```
-docker rm `docker ps -a -q -f status=exited`
+docker rm -v `docker ps -a -q -f status=exited`
 ```
 
 ### Delete dangling images


### PR DESCRIPTION
Added -v to container cleanup command. This will never delete bind-mount volumes, and this will cleanup otherwise orphaned managed volumes.