### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ That's it, you have a running Docker container.
 
 ## Containers
 
-[Your basic isolated Docker process](http://etherealmind.com/basics-docker-containers-hypervisors-coreos/).  Containers are to Virtual Machines as threads are to processes.  Or you can think of them as chroots on steroids.
+[Your basic isolated Docker process](http://etherealmind.com/basics-docker-containers-hypervisors-coreos/).  Containers are to Virtual Machines as threads are to processes and are a easy way to segregate applications and control what data and software are installed.  
 
 ### Lifecycle
 


### PR DESCRIPTION
Docker container aren't chroot on steroids without SELinux or similar, container root equals host root.