### PR TITLE
Update legacy docker.io links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,15 @@ That's it, you have a running Docker container.
 
 ### Lifecycle
 
-* [`docker create`](http://docs.docker.io/reference/commandline/cli/#create) creates a container but does not start it.
-* [`docker run`](http://docs.docker.io/reference/commandline/cli/#run) creates and starts a container in one operation.
-* [`docker stop`](http://docs.docker.io/reference/commandline/cli/#stop) stops it.
-* [`docker start`](http://docs.docker.io/reference/commandline/cli/#start) will start it again.
-* [`docker restart`](http://docs.docker.io/reference/commandline/cli/#restart) restarts a container.
-* [`docker rm`](http://docs.docker.io/reference/commandline/cli/#rm) deletes a container.
-* [`docker kill`](http://docs.docker.io/reference/commandline/cli/#kill) sends a SIGKILL to a container.
-* [`docker attach`](http://docs.docker.io/reference/commandline/cli/#attach) will connect to a running container.
-* [`docker wait`](http://docs.docker.io/reference/commandline/cli/#wait) blocks until container stops.
+* [`docker create`](https://docs.docker.com/reference/commandline/cli/#create) creates a container but does not start it.
+* [`docker run`](https://docs.docker.com/reference/commandline/cli/#run) creates and starts a container in one operation.
+* [`docker stop`](https://docs.docker.com/reference/commandline/cli/#stop) stops it.
+* [`docker start`](https://docs.docker.com/reference/commandline/cli/#start) will start it again.
+* [`docker restart`](https://docs.docker.com/reference/commandline/cli/#restart) restarts a container.
+* [`docker rm`](https://docs.docker.com/reference/commandline/cli/#rm) deletes a container.
+* [`docker kill`](https://docs.docker.com/reference/commandline/cli/#kill) sends a SIGKILL to a container.
+* [`docker attach`](https://docs.docker.com/reference/commandline/cli/#attach) will connect to a running container.
+* [`docker wait`](https://docs.docker.com/reference/commandline/cli/#wait) blocks until container stops.
 
 If you want to run and then interact with a container, `docker start`, then spawn a shell as described in [Executing Commands](https://github.com/wsargent/docker-cheat-sheet/#executing-commands).
 
@@ -109,7 +109,7 @@ If you want to poke around in an image, `docker run -t -i <myimage> <myshell>` t
 
 If you want to map a directory on the host to a docker container, `docker run -v $HOSTDIR:$DOCKERDIR`.  Also see [Volumes](https://github.com/wsargent/docker-cheat-sheet/#volumes).
 
-If you want to integrate a container with a [host process manager](http://docs.docker.io/use/host_integration/), start the daemon with `-r=false` then use `docker start -a`.
+If you want to integrate a container with a [host process manager](https://docs.docker.com/articles/host_integration/), start the daemon with `-r=false` then use `docker start -a`.
 
 If you want to expose container ports through the host, see the [exposing ports](#exposing-ports) section.
 
@@ -117,14 +117,14 @@ Restart policies on crashed docker instances are [covered here](http://container
 
 ### Info
 
-* [`docker ps`](http://docs.docker.io/reference/commandline/cli/#ps) shows running containers.
-* [`docker inspect`](http://docs.docker.io/reference/commandline/cli/#inspect) looks at all the info on a container (including IP address).
-* [`docker logs`](http://docs.docker.io/reference/commandline/cli/#logs) gets logs from container.
-* [`docker events`](http://docs.docker.io/reference/commandline/cli/#events) gets events from container.
-* [`docker port`](http://docs.docker.io/reference/commandline/cli/#port) shows public facing port of container.
-* [`docker top`](http://docs.docker.io/reference/commandline/cli/#top) shows running processes in container.
-* [`docker stats`](http://docs.docker.com/reference/commandline/cli/#stats) shows containers' resource usage statistics.
-* [`docker diff`](http://docs.docker.io/reference/commandline/cli/#diff) shows changed files in the container's FS.
+* [`docker ps`](https://docs.docker.com/reference/commandline/cli/#ps) shows running containers.
+* [`docker logs`](https://docs.docker.com/reference/commandline/cli/#logs) gets logs from container.
+* [`docker inspect`](https://docs.docker.com/reference/commandline/cli/#inspect) looks at all the info on a container (including IP address).
+* [`docker events`](https://docs.docker.com/reference/commandline/cli/#events) gets events from container.
+* [`docker port`](https://docs.docker.com/reference/commandline/cli/#port) shows public facing port of container.
+* [`docker top`](https://docs.docker.com/reference/commandline/cli/#top) shows running processes in container.
+* [`docker stats`](https://docs.docker.com/reference/commandline/cli/#stats) shows containers' resource usage statistics.
+* [`docker diff`](https://docs.docker.com/reference/commandline/cli/#diff) shows changed files in the container's FS.
 
 `docker ps -a` shows running and stopped containers.
 
@@ -132,8 +132,8 @@ Restart policies on crashed docker instances are [covered here](http://container
 
 There doesn't seem to be a way to use docker directly to import files into a container's filesystem.  The closest thing is to mount a host file or directory as a data volume and copy it from inside the container.
 
-* [`docker cp`](http://docs.docker.io/reference/commandline/cli/#cp) copies files or folders out of a container's filesystem.
-* [`docker export`](http://docs.docker.io/reference/commandline/cli/#export) turns container filesystem into tarball archive stream to STDOUT.
+* [`docker cp`](http://docs.docker.com/reference/commandline/cli/#cp) copies files or folders out of a container's filesystem.
+* [`docker export`](https://docs.docker.com/reference/commandline/cli/#export) turns container filesystem into tarball archive stream to STDOUT.
 
 ### Executing Commands
 
@@ -147,19 +147,19 @@ Images are just [templates for docker containers](https://docs.docker.com/introd
 
 ### Lifecycle
 
-* [`docker images`](http://docs.docker.io/reference/commandline/cli/#images) shows all images.
-* [`docker import`](http://docs.docker.io/reference/commandline/cli/#import) creates an image from a tarball.
-* [`docker build`](http://docs.docker.io/reference/commandline/cli/#build) creates image from Dockerfile.
-* [`docker commit`](http://docs.docker.io/reference/commandline/cli/#commit) creates image from a container.
-* [`docker rmi`](http://docs.docker.io/reference/commandline/cli/#rmi) removes an image.
-* [`docker insert`](http://docs.docker.io/reference/commandline/cli/#insert) inserts a file from URL into image. (kind of odd, you'd think images would be immutable after create)
-* [`docker load`](http://docs.docker.io/reference/commandline/cli/#load) loads an image from a tar archive as STDIN, including images and tags (as of 0.7).
-* [`docker save`](http://docs.docker.io/reference/commandline/cli/#save) saves an image to a tar archive stream to STDOUT with all parent layers, tags & versions (as of 0.7).
+* [`docker images`](https://docs.docker.com/reference/commandline/cli/#images) shows all images.
+* [`docker import`](https://docs.docker.com/reference/commandline/cli/#import) creates an image from a tarball.
+* [`docker build`](https://docs.docker.com/reference/commandline/cli/#build) creates image from Dockerfile.
+* [`docker commit`](https://docs.docker.com/reference/commandline/cli/#commit) creates image from a container.
+* [`docker rmi`](https://docs.docker.com/reference/commandline/cli/#rmi) removes an image.
+* [`docker insert`](https://docs.docker.com/reference/commandline/cli/#insert) inserts a file from URL into image. (kind of odd, you'd think images would be immutable after create)
+* [`docker load`](https://docs.docker.com/reference/commandline/cli/#load) loads an image from a tar archive as STDIN, including images and tags (as of 0.7).
+* [`docker save`](https://docs.docker.com/reference/commandline/cli/#save) saves an image to a tar archive stream to STDOUT with all parent layers, tags & versions (as of 0.7).
 
 ### Info
 
-* [`docker history`](http://docs.docker.io/reference/commandline/cli/#history) shows history of image.
-* [`docker tag`](http://docs.docker.io/reference/commandline/cli/#tag) tags an image to a name (local or registry).
+* [`docker history`](https://docs.docker.com/reference/commandline/cli/#history) shows history of image.
+* [`docker tag`](https://docs.docker.com/reference/commandline/cli/#tag) tags an image to a name (local or registry).
 
 Docker image ids are [sensitive information](https://medium.com/@quayio/your-docker-image-ids-are-secrets-and-its-time-you-treated-them-that-way-f55e9f14c1a4) and should not be exposed to the outside world.  Treat them like passwords.
 
@@ -167,14 +167,14 @@ Docker image ids are [sensitive information](https://medium.com/@quayio/your-doc
 
 A repository is a *hosted* collection of tagged images that together create the file system for a container.
 
-A registry is a *host* -- a server that stores repositories and provides an HTTP API for [managing the uploading and downloading of repositories](http://docs.docker.io/use/workingwithrepository/).
+A registry is a *host* -- a server that stores repositories and provides an HTTP API for [managing the uploading and downloading of repositories](https://docs.docker.com/userguide/dockerrepos/).
 
-Docker.io hosts its own [index](https://index.docker.io/) to a central registry which contains a large number of repositories.  Having said that, the central docker registry [does not do a good job of verifying images](https://titanous.com/posts/docker-insecurity) and should be avoided if you're worried about security.
+Docker.com hosts its own [index](https://registry.hub.docker.com/) to a central registry which contains a large number of repositories.  Having said that, the central docker registry [does not do a good job of verifying images](https://titanous.com/posts/docker-insecurity) and should be avoided if you're worried about security.
 
-* [`docker login`](http://docs.docker.io/reference/commandline/cli/#login) to login to a registry.
-* [`docker search`](http://docs.docker.io/reference/commandline/cli/#search) searches registry for image.
-* [`docker pull`](http://docs.docker.io/reference/commandline/cli/#pull) pulls an image from registry to local machine.
-* [`docker push`](http://docs.docker.io/reference/commandline/cli/#push) pushes an image to the registry from local machine.
+* [`docker login`](https://docs.docker.com/reference/commandline/cli/#login) to login to a registry.
+* [`docker search`](https://docs.docker.com/reference/commandline/cli/#search) searches registry for image.
+* [`docker pull`](https://docs.docker.com/reference/commandline/cli/#pull) pulls an image from registry to local machine.
+* [`docker push`](https://docs.docker.com/reference/commandline/cli/#push) pushes an image to the registry from local machine.
 
 ### Run local registry
 
@@ -190,19 +190,19 @@ In order to push to this repository tag image with `repositoryHostName:5000/imag
 ### Instructions
 
 * [.dockerignore](https://docs.docker.com/reference/builder/#the-dockerignore-file)
-* [FROM](http://docs.docker.io/reference/builder/#from)
-* [MAINTAINER](http://docs.docker.io/reference/builder/#maintainer)
-* [RUN](http://docs.docker.io/reference/builder/#run)
-* [CMD](http://docs.docker.io/reference/builder/#cmd)
-* [EXPOSE](http://docs.docker.io/reference/builder/#expose)
-* [ENV](http://docs.docker.io/reference/builder/#env)
-* [ADD](http://docs.docker.io/reference/builder/#add)
-* [COPY](http://docs.docker.io/reference/builder/#copy)
-* [ENTRYPOINT](http://docs.docker.io/reference/builder/#entrypoint)
-* [VOLUME](http://docs.docker.io/reference/builder/#volume)
-* [USER](http://docs.docker.io/reference/builder/#user)
-* [WORKDIR](http://docs.docker.io/reference/builder/#workdir)
-* [ONBUILD](http://docs.docker.io/reference/builder/#onbuild)
+* [FROM](https://docs.docker.com/reference/builder/#from)
+* [MAINTAINER](https://docs.docker.com/reference/builder/#maintainer)
+* [RUN](https://docs.docker.com/reference/builder/#run)
+* [CMD](https://docs.docker.com/reference/builder/#cmd)
+* [EXPOSE](https://docs.docker.com/reference/builder/#expose)
+* [ENV](https://docs.docker.com/reference/builder/#env)
+* [ADD](https://docs.docker.com/reference/builder/#add)
+* [COPY](https://docs.docker.com/reference/builder/#copy)
+* [ENTRYPOINT](https://docs.docker.com/reference/builder/#entrypoint)
+* [VOLUME](https://docs.docker.com/reference/builder/#volume)
+* [USER](https://docs.docker.com/reference/builder/#user)
+* [WORKDIR](https://docs.docker.com/reference/builder/#workdir)
+* [ONBUILD](https://docs.docker.com/reference/builder/#onbuild)
 
 ### Tutorial
 
@@ -210,7 +210,7 @@ In order to push to this repository tag image with `repositoryHostName:5000/imag
 
 ### Examples
 
-* [Examples](http://docs.docker.io/reference/builder/#dockerfile-examples)
+* [Examples](https://docs.docker.com/reference/builder/#dockerfile-examples)
 * [Best practices for writing Dockerfiles](https://docs.docker.com/articles/dockerfile_best-practices/)
 * [Michael Crosby](http://crosbymichael.com/) has some more [Dockerfiles best practices](http://crosbymichael.com/dockerfile-best-practices.html) / [take 2](http://crosbymichael.com/dockerfile-best-practices-take-2.html).
 
@@ -233,7 +233,7 @@ Note that if you're using [aufs](http://en.wikipedia.org/wiki/Aufs) as your file
 
 ## Links
 
-Links are how Docker containers talk to each other [through TCP/IP ports](http://docs.docker.io/use/working_with_links_names/).  [Linking into Redis](http://docs.docker.io/use/working_with_links_names/#links-service-discovery-for-docker) and [Atlassian](http://blogs.atlassian.com/2013/11/docker-all-the-things-at-atlassian-automation-and-wiring/) show worked examples.  You can also (in 0.11) resolve [links by hostname](http://docs.docker.io/use/working_with_links_names/#resolving-links-by-name).
+Links are how Docker containers talk to each other [through TCP/IP ports](https://docs.docker.com/userguide/dockerlinks/).  [Linking into Redis](https://docs.docker.com/examples/running_redis_service/) and [Atlassian](http://blogs.atlassian.com/2013/11/docker-all-the-things-at-atlassian-automation-and-wiring/) show worked examples.  You can also (in 0.11) resolve [links by hostname](https://docs.docker.com/userguide/dockerlinks/#updating-the-etchosts-file).
 
 NOTE: If you want containers to ONLY communicate with each other through links, start the docker daemon with `-icc=false` to disable inter process communication.
 
@@ -297,7 +297,7 @@ The fastest way is to map the container port to the host port (only using localh
 docker run -p 127.0.0.1:$HOSTPORT:$CONTAINERPORT --name CONTAINER -t someimage
 ```
 
-If you don't want to use the `-p` option on the command line, you can persist port forwarding by using [EXPOSE](http://docs.docker.io/reference/builder/#expose):
+If you don't want to use the `-p` option on the command line, you can persist port forwarding by using [EXPOSE](https://docs.docker.com/reference/builder/#expose):
 
 ```
 EXPOSE <CONTAINERPORT>


### PR DESCRIPTION
docker.io now redirects to docker.com, and index.docker.io redirects to registry.hub.docker.com.
This patch reflects these changes.

The only non-trivial change is in the `Links` section, I tried my best to fix the obsolete links with their modern replacements.