### PR TITLE
Add A simple way to monitor resource utilization

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,21 @@ ID=$(docker run -d image-name /bin/bash)
 gzip -dc image.tgz | docker import - flat-image-name
 ```
 
+### Monitor system resource utilization for running containers
+
+To check the CPU, memory and network i/o usage, you can use:
+
+```
+docker stats <container>
+``` 
+
+for a single container or 
+
+```
+docker stats $(docker ps -q)
+```
+
+to monitor all containers on the docker host.
 
 ## Tools
 


### PR DESCRIPTION
Maybe this is a useful tip, because there is no example how to monitor *all* running containers in the official documentation: http://docs.docker.com/reference/commandline/stats/ .