### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ docker rmi $(docker images -q)
 docker images -viz | dot -Tpng -o docker.png
 ```
 
-### Slimming down Docker containers  [Intercity Blog](http://bit.ly/1DycW5A)
+### Slimming down Docker containers  [Intercity Blog](http://bit.ly/1Wwo61N)
 
 - Cleaning APT
 ```


### PR DESCRIPTION
Fix Intercity Blog link that was returning 404; the post was apparently moved.