### PR TITLE
Fix the volume removal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you want to run and then interact with a container, `docker start`, then spaw
 
 If you want a transient container, `docker run --rm` will remove the container after it stops.
 
-If you want to remove also the volumes associated with the container, the deletion of the container must include the -v switch like in `docker --rm -v`.
+If you want to remove also the volumes associated with the container, the deletion of the container must include the -v switch like in `docker rm -v`.
 
 If you want to poke around in an image, `docker run -t -i <myimage> <myshell>` to open a tty.
 


### PR DESCRIPTION
The example demonstrating how to remove the volumes associated with a container is probably supposed to be `docker rm -v` instead of `docker --rm -v`.

If the example is meant to be about `docker run`, then based on docker/docker@5ceff3f191ec7678362d2538aab7ed54ce17b859 `docker run --rm` should automatically remove the volumes associated with the transient container.