### PR TITLE
Added info for Docker 1.9 `docker volume` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ Because volumes are isolated filesystems, they are often used to store state fro
 
 See [advanced volumes](http://crosbymichael.com/advanced-docker-volumes.html) for more details.  Container42 is [also helpful](http://container42.com/2014/11/03/docker-indepth-volumes/).
 
-For an easy way to clean abandoned volumes, see [docker-cleanup-volumes](https://github.com/chadoe/docker-cleanup-volumes)
+For an easy way to clean abandoned volumes, see [docker-cleanup-volumes](https://github.com/chadoe/docker-cleanup-volumes).
+
+As of 1.9, there are [volume specific commands](http://docs.docker.com/engine/reference/commandline/volume_ls/) like create, ls, and rm. (Thus no need for the above script to clean abandoned volumes - see [delete dangling volumes](#delete-dangling-volumes) in the quick reference, below.)
 
 As of 1.3, you can [map MacOS host directories as docker volumes](https://docs.docker.com/userguide/dockervolumes/#mount-a-host-directory-as-a-data-volume) through boot2docker:
 
@@ -453,6 +455,16 @@ docker rmi $(docker images -q -f dangling=true)
 ```
 docker rmi $(docker images -q)
 ```
+
+### Delete dangling volumes
+
+As of Docker 1.9:
+
+```
+docker volume rm $(docker volume ls -q -f dangling=true)
+```
+
+In 1.9.0, the filter `dangling=false` does _not_ work - it is ignored and will list all volumes.
 
 ### Show image dependencies
 


### PR DESCRIPTION
In particular, there is a now a way within Docker only (no outside scripts) to list and remove dangling volumes.