### PR TITLE
Update broken link to terms/layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ In order to push to this repository tag image with `repositoryHostName:5000/imag
 
 ## Layers
 
-The versioned filesystem in Docker is based on layers.  They're like [git commits or changesets for filesystems](https://docs.docker.com/terms/layer/).
+The versioned filesystem in Docker is based on layers.  They're like [git commits or changesets for filesystems](https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/).
 
 Note that if you're using [aufs](https://en.wikipedia.org/wiki/Aufs) as your filesystem, Docker does not always remove data volumes containers layers when you delete a container!  See [PR 8484](https://github.com/docker/docker/pull/8484) for more details.
 


### PR DESCRIPTION
[The new link](https://docs.docker.com/engine/userguide/storagedriver/imagesandcontainers/) isnt a 1:1 replacement.  It _appears_ terms/layer was removed at [1.7](https://docs.docker.com/v1.7/terms/layer/#layer).  

The content on this new link covers layers similar to how the [previous page](https://docs.docker.com/v1.6/terms/layer/#layer) did. imo