### PR TITLE
docs: fix `docker meets the ide` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Here are some common text editors and their syntax highlighting modules you coul
 * [Atom](https://atom.io/packages/language-docker)
 * [Vim](https://github.com/ekalinin/Dockerfile.vim)
 * [Emacs](https://github.com/spotify/dockerfile-mode)
-* For a most comprehensive list of editors and IDEs, check [Docker meets the IDE] (https://github.com/spotify/dockerfile-mode)
+* For a most comprehensive list of editors and IDEs, check [Docker meets the IDE] (https://domeide.github.io/)
 
 ### Instructions
 

--- a/zh-cn/README.md
+++ b/zh-cn/README.md
@@ -229,7 +229,7 @@ Docker.com 把它自己的[索引](https://hub.docker.com/)托管到了它的仓
 * [Atom](https://atom.io/packages/language-docker)
 * [Vim](https://github.com/ekalinin/Dockerfile.vim)
 * [Emacs](https://github.com/spotify/dockerfile-mode)
-* 如果要找更全面的关于编辑器或者 IDE 的内容，请看 [当 Docker 遇上 IDE](https://github.com/spotify/dockerfile-mode)
+* 如果要找更全面的关于编辑器或者 IDE 的内容，请看 [当 Docker 遇上 IDE](https://domeide.github.io/)
 
 ### 指令
 


### PR DESCRIPTION
hi @lherrera , i check your links, 

here https://github.com/wsargent/docker-cheat-sheet/pull/97/files#diff-04c6e90faac2675aa89e2176d2eec7d8R230

> +* [Emacs](https://github.com/spotify/dockerfile-mode)
 +* For a most comprehensive list of editors and IDEs, check [Docker meets the IDE] (https://github.com/spotify/dockerfile-mode)

you post the same links. and i google the  `Docker meets the IDE`, yes, it is a beautiful github site.
and i think what you want to tell us is this site. right?

wait for your review.
