### PR TITLE
Replace Tutorials link 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl -sSL https://get.docker.com/ | sh
 
 If you're not willing to run a random shell script, please see the [installation](https://docs.docker.com/installation/) instructions for your distribution.
 
-If you are a complete Docker newbie, you should follow the [series of tutorials](https://docs.docker.com/linux/started/) now.
+If you are a complete Docker newbie, you should follow the [series of tutorials](https://docs.docker.com/engine/getstarted/) now.
 
 ### Mac OS X
 


### PR DESCRIPTION
docs.docker.com/linux/started -> docs.docker.com/engine/getstarted
