### PR TITLE
fix to get single IPAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ docker commit -run='{"Cmd":["postgres", "-too -many -opts"]}' $(dl) postgres
 ### Get IP address
 
 ```
-docker inspect $(dl) | grep IPAddress | cut -d '"' -f 4
+docker inspect $(dl) | grep -wm1 IPAddress | cut -d '"' -f 4
 ```
 
 or install [jq](https://stedolan.github.io/jq/):


### PR DESCRIPTION
Original command to get IPAddress returns two IPAddresses because of multiple "IPAddress" in `docker inspect` JSON output.  

Added `-w` flag so grep doesn't match "SecondaryIPAddresses" and `-m1` so we only get one match.