### PR TITLE
previously only printing the line again

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,7 +761,7 @@ docker ps -a -f ancestor=ubuntu
 
 Remove all untagged images
 ```
-docker rmi $(docker images | grep “^” | awk “{print $3}”)
+docker rmi $(docker images | grep “^” | awk '{split($0,a," "); print a[3]}')
 ```
 
 Remove container by a regular expression


### PR DESCRIPTION
added awk split to split the docker images output and return image id only